### PR TITLE
Add default timeout option

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,49 +1,14 @@
-#-------------------------------------------------------------------------------------------------------------
-# Copyright (c) Microsoft Corporation. All rights reserved.
-# Licensed under the MIT License. See https://go.microsoft.com/fwlink/?linkid=2090316 for license information.
-#-------------------------------------------------------------------------------------------------------------
+FROM mcr.microsoft.com/devcontainers/anaconda:0-3
 
-FROM continuumio/anaconda3
-
-# This Dockerfile adds a non-root user with sudo access. Use the "remoteUser"
-# property in devcontainer.json to use it. On Linux, the container user's GID/UIDs
-# will be updated to match your local UID/GID (when using the dockerFile property).
-# See https://aka.ms/vscode-remote/containers/non-root-user for details.
-ARG USERNAME=vscode
-ARG USER_UID=1000
-ARG USER_GID=$USER_UID
-
-# Copy environment.yml (if found) to a temp locaition so we update the environment. Also
+# Copy environment.yml (if found) to a temp location so we update the environment. Also
 # copy "noop.txt" so the COPY instruction does not fail if no environment.yml exists.
 COPY environment.yml* .devcontainer/noop.txt /tmp/conda-tmp/
+RUN if [ -f "/tmp/conda-tmp/environment.yml" ]; then umask 0002 && /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
+    && rm -rf /tmp/conda-tmp
 
-# Configure apt and install packages
-RUN apt-get update \
-    && export DEBIAN_FRONTEND=noninteractive \
-    && apt-get -y install --no-install-recommends apt-utils dialog 2>&1 \
-    #
-    # Verify git, process tools, lsb-release (common in install instructions for CLIs) installed
-    && apt-get -y install git openssh-client less iproute2 procps iproute2 lsb-release \
-    #
-    # Install pylint
-    && /opt/conda/bin/pip install pylint \
-    #
-    # Update Python environment based on environment.yml (if present)
-    && if [ -f "/tmp/conda-tmp/environment.yml" ]; then /opt/conda/bin/conda env update -n base -f /tmp/conda-tmp/environment.yml; fi \
-    && rm -rf /tmp/conda-tmp \
-    #
-    # Create a non-root user to use if preferred - see https://aka.ms/vscode-remote/containers/non-root-user.
-    && groupadd --gid $USER_GID $USERNAME \
-    && useradd -s /bin/bash --uid $USER_UID --gid $USER_GID -m $USERNAME \
-    # [Optional] Add sudo support for the non-root user
-    && apt-get install -y sudo \
-    && echo $USERNAME ALL=\(root\) NOPASSWD:ALL > /etc/sudoers.d/$USERNAME\
-    && chmod 0440 /etc/sudoers.d/$USERNAME \
-    #
-    # Clean up
-    && apt-get autoremove -y \
-    && apt-get clean -y \
-    && rm -rf /var/lib/apt/lists/*
+# [Optional] Uncomment this section to install additional OS packages.
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends python3-distutils
 
 COPY requirements.txt /tmp/pip-tmp/
 RUN /opt/conda/bin/pip --disable-pip-version-check --no-cache-dir install -r /tmp/pip-tmp/requirements.txt \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,29 +1,29 @@
-// For format details, see https://aka.ms/vscode-remote/devcontainer.json or this file's README at:
-// https://github.com/microsoft/vscode-dev-containers/tree/v0.122.1/containers/python-3-anaconda
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/anaconda
 {
-	"name": "Python 3 - Anaconda",
-	"context": "..",
-	"dockerFile": "Dockerfile",
-
-	// Set *default* container specific settings.json values on container create.
-	"settings": { 
-		"terminal.integrated.shell.linux": "/bin/bash",
-		"python.pythonPath": "/opt/conda/bin/python",
-		"python.linting.enabled": true,
-		"python.linting.pylintEnabled": true,
-		"python.linting.pylintPath": "/opt/conda/bin/pylint"
+	"name": "Anaconda (Python 3)",
+	"build": { 
+		"context": "..",
+		"dockerfile": "Dockerfile"
 	},
 
-	// Add the IDs of extensions you want installed when the container is created.
-	"extensions": [
-		"ms-python.python",
-		"mutantdino.resourcemonitor",
-		"ms-python.vscode-pylance"
-	],
+	"customizations": {
+		"vscode": {
+			"extensions": [
+				"ms-python.python"
+			]
+		}
+	},
 
+	// Features to add to the dev container. More info: https://containers.dev/features.
+	// "features": {},
 	"containerEnv": {
+		// For the following to work you need to have set he environment variable
+		// in windows and run:
+		// setx WSLENV "$($env:WSLENV):CANOPY_ADMIN_TOOLS_CONFIGURATION_URL"
 		"CANOPY_PYTHON_INTEGRATION_TEST_CREDENTIALS": "${localEnv:CANOPY_PYTHON_INTEGRATION_TEST_CREDENTIALS}"
-	},
+	}
+
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],
@@ -31,6 +31,9 @@
 	// Use 'postCreateCommand' to run commands after the container is created.
 	// "postCreateCommand": "python --version",
 
-	// Uncomment to connect as a non-root user. See https://aka.ms/vscode-remote/containers/non-root.
-	// "remoteUser": "vscode"
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
 }

--- a/integration_tests/conftest.py
+++ b/integration_tests/conftest.py
@@ -1,0 +1,14 @@
+from asyncio import get_event_loop
+import pytest
+import integration_tests
+
+
+@pytest.fixture(scope="session")
+def event_loop():
+    loop = get_event_loop()
+    yield loop
+
+@pytest.fixture(scope='session')
+async def environment() -> integration_tests.Environment:
+    async with integration_tests.Environment() as e:
+        yield e

--- a/integration_tests/test_config.py
+++ b/integration_tests/test_config.py
@@ -6,7 +6,7 @@ import pytest
 import numpy as np
 
 import canopy
-import integration_tests
+from integration_tests import Environment
 
 default_car_name = 'Canopy F1 Car 2019'
 test_car_name = 'Python Automated Test Car'
@@ -32,122 +32,110 @@ class TestConfig:
     def state(self) -> State:
         return State()
 
-    async def test_0100_it_should_load_a_default_config(self, state: State):
-        async with integration_tests.Environment() as environment:
-            state.default_car = await canopy.load_default_config(
+    async def test_0100_it_should_load_a_default_config(self, state: State, environment: Environment):
+        state.default_car = await canopy.load_default_config(
+            environment.session,
+            'car',
+            default_car_name)
+
+        assert state.default_car is not None
+        assert default_car_name == state.default_car.name
+
+    async def test_0200_it_should_create_a_config(self, state: State, environment: Environment):
+
+        state.test_car_config_id = await canopy.create_config(
+            environment.session,
+            'car',
+            test_car_name,
+            state.default_car.raw_data,
+            test_car_custom_properties)
+
+        assert state.test_car_config_id is not None
+
+        state.configs_to_remove.append(state.test_car_config_id)
+
+    async def test_0210_it_should_create_a_config_with_no_custom_properties(self, state: State, environment: Environment):
+        state.test_car_config_id_2 = await canopy.create_config(
+            environment.session,
+            'car',
+            test_car_name_2,
+            state.default_car.raw_data)
+
+        assert state.test_car_config_id_2 is not None
+
+        state.configs_to_remove.append(state.test_car_config_id_2)
+
+    async def test_0220_it_should_create_a_config_containing_numpy_arrays(self, state: State, environment: Environment):
+        state.default_car.data.chassis.rUndertrayFront = np.array(state.default_car.data.chassis.rUndertrayFront)
+
+        state.test_car_config_id = await canopy.create_config(
+            environment.session,
+            'car',
+            test_car_name,
+            state.default_car.raw_data,
+            test_car_custom_properties)
+
+        assert state.test_car_config_id is not None
+
+        state.configs_to_remove.append(state.test_car_config_id)
+
+    async def test_0300_it_should_find_a_config_by_name(self, state: State, environment: Environment):
+        car = await canopy.find_config(
+            environment.session,
+            'car',
+            owner_username=environment.data.authentication.username,
+            name=test_car_name)
+
+        assert car.document.document_id == state.test_car_config_id
+
+    async def test_0400_it_should_find_a_config_by_custom_properties(self, state: State, environment: Environment):
+        car = await canopy.find_config(
+            environment.session,
+            'car',
+            owner_username=environment.data.authentication.username,
+            custom_properties=test_car_custom_properties)
+
+        assert car.document.document_id == state.test_car_config_id
+
+    async def test_0500_it_should_find_a_config_by_multiple_criteria(self, state: State, environment: Environment):
+        car = await canopy.find_config(
+            environment.session,
+            'car',
+            owner_username=environment.data.authentication.username,
+            name=test_car_name,
+            custom_properties=test_car_custom_properties)
+
+        assert car.document.document_id == state.test_car_config_id
+
+    async def test_0600_it_should_load_a_config_by_id(self, state: State, environment: Environment):
+        car = await canopy.load_config(
+            environment.session,
+            state.test_car_config_id)
+
+        assert car.document.document_id == state.test_car_config_id
+
+    async def test_0700_it_should_convert_configs_to_local_configs(self, state: State, environment: Environment):
+        car = await canopy.load_config(
+            environment.session,
+            state.test_car_config_id)
+        local_car = car.to_local_config()
+
+        assert car.document.document_id == state.test_car_config_id
+        assert local_car.config_id == state.test_car_config_id
+
+    async def test_0700_it_should_convert_configs_to_local_configs_with_no_custom_properties(self, state: State, environment: Environment):
+        car = await canopy.load_config(
+            environment.session,
+            state.test_car_config_id_2)
+        local_car = car.to_local_config()
+
+        assert car.document.document_id == state.test_car_config_id_2
+        assert local_car.config_id == state.test_car_config_id_2
+
+    async def test_9000_it_should_remove_configs(self, state: State, environment: Environment):
+        tasks: List[Future] = []
+        for config_id in state.configs_to_remove:
+            tasks.append(asyncio.ensure_future(canopy.delete_config(
                 environment.session,
-                'car',
-                default_car_name)
-
-            assert state.default_car is not None
-            assert default_car_name == state.default_car.name
-
-    async def test_0200_it_should_create_a_config(self, state: State):
-
-        async with integration_tests.Environment() as environment:
-            state.test_car_config_id = await canopy.create_config(
-                environment.session,
-                'car',
-                test_car_name,
-                state.default_car.raw_data,
-                test_car_custom_properties)
-
-            assert state.test_car_config_id is not None
-
-            state.configs_to_remove.append(state.test_car_config_id)
-
-    async def test_0210_it_should_create_a_config_with_no_custom_properties(self, state: State):
-
-        async with integration_tests.Environment() as environment:
-            state.test_car_config_id_2 = await canopy.create_config(
-                environment.session,
-                'car',
-                test_car_name_2,
-                state.default_car.raw_data)
-
-            assert state.test_car_config_id_2 is not None
-
-            state.configs_to_remove.append(state.test_car_config_id_2)
-
-    async def test_0220_it_should_create_a_config_containing_numpy_arrays(self, state: State):
-        async with integration_tests.Environment() as environment:
-            state.default_car.data.chassis.rUndertrayFront = np.array(state.default_car.data.chassis.rUndertrayFront)
-
-            state.test_car_config_id = await canopy.create_config(
-                environment.session,
-                'car',
-                test_car_name,
-                state.default_car.raw_data,
-                test_car_custom_properties)
-
-            assert state.test_car_config_id is not None
-
-            state.configs_to_remove.append(state.test_car_config_id)
-
-    async def test_0300_it_should_find_a_config_by_name(self, state: State):
-        async with integration_tests.Environment() as environment:
-            car = await canopy.find_config(
-                environment.session,
-                'car',
-                owner_username=environment.data.authentication.username,
-                name=test_car_name)
-
-            assert car.document.document_id == state.test_car_config_id
-
-    async def test_0400_it_should_find_a_config_by_custom_properties(self, state: State):
-        async with integration_tests.Environment() as environment:
-            car = await canopy.find_config(
-                environment.session,
-                'car',
-                owner_username=environment.data.authentication.username,
-                custom_properties=test_car_custom_properties)
-
-            assert car.document.document_id == state.test_car_config_id
-
-    async def test_0500_it_should_find_a_config_by_multiple_criteria(self, state: State):
-        async with integration_tests.Environment() as environment:
-            car = await canopy.find_config(
-                environment.session,
-                'car',
-                owner_username=environment.data.authentication.username,
-                name=test_car_name,
-                custom_properties=test_car_custom_properties)
-
-            assert car.document.document_id == state.test_car_config_id
-
-    async def test_0600_it_should_load_a_config_by_id(self, state: State):
-        async with integration_tests.Environment() as environment:
-            car = await canopy.load_config(
-                environment.session,
-                state.test_car_config_id)
-
-            assert car.document.document_id == state.test_car_config_id
-
-    async def test_0700_it_should_convert_configs_to_local_configs(self, state: State):
-        async with integration_tests.Environment() as environment:
-            car = await canopy.load_config(
-                environment.session,
-                state.test_car_config_id)
-            local_car = car.to_local_config()
-
-            assert car.document.document_id == state.test_car_config_id
-            assert local_car.config_id == state.test_car_config_id
-
-    async def test_0700_it_should_convert_configs_to_local_configs_with_no_custom_properties(self, state: State):
-        async with integration_tests.Environment() as environment:
-            car = await canopy.load_config(
-                environment.session,
-                state.test_car_config_id_2)
-            local_car = car.to_local_config()
-
-            assert car.document.document_id == state.test_car_config_id_2
-            assert local_car.config_id == state.test_car_config_id_2
-
-    async def test_9000_it_should_remove_configs(self, state: State):
-        async with integration_tests.Environment() as environment:
-            tasks: List[Future] = []
-            for config_id in state.configs_to_remove:
-                tasks.append(asyncio.ensure_future(canopy.delete_config(
-                    environment.session,
-                    config_id)))
-            await asyncio.gather(*tasks)
+                config_id)))
+        await asyncio.gather(*tasks)

--- a/integration_tests/test_study.py
+++ b/integration_tests/test_study.py
@@ -6,7 +6,7 @@ import pytest
 import logging
 
 import canopy
-import integration_tests
+from integration_tests import Environment
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +48,7 @@ class TestStudy:
     async def wait_for_and_verify_study(
             self,
             state: State,
-            environment: integration_tests.Environment,
+            environment: Environment,
             study_id: str,
             expected_name: str) -> canopy.StudyResult:
         assert study_id is not None
@@ -64,259 +64,246 @@ class TestStudy:
         assert wait_result.data.job_count == wait_result.data.completed_job_count
         return wait_result
 
-    async def test_0100_it_should_create_a_study_from_local_configs(self, state: State):
-        async with integration_tests.Environment() as environment:
-            state.default_car = await canopy.load_default_config(
+    async def test_0100_it_should_create_a_study_from_local_configs(self, state: State, environment: Environment):
+        state.default_car = await canopy.load_default_config(
+            environment.session,
+            'car',
+            default_car_name)
+        state.default_weather = await canopy.load_default_config(
+            environment.session,
+            'weather',
+            default_weather_name)
+
+        state.study_id = await canopy.create_study(
+            environment.session,
+            'ApexSim',  # Intentionally wrong casing.
+            test_study_name,
+            [
+                state.default_car,
+                state.default_weather,
+            ],
+            test_custom_properties)
+        logger.info('Study ID is {}'.format(state.study_id))
+
+        study = await self.wait_for_and_verify_study(state, environment, state.study_id, test_study_name)
+
+        properties = canopy.ensure_dict(study.document.properties)
+        assert test_study_property_value == properties[test_study_property_key]
+        assert study.simulation_count == 1
+        assert study.succeeded_simulation_count == 1
+        assert study.data.job_count == 1
+
+    async def test_0200_it_should_create_a_study_from_references_and_loaded_configs(self, state: State, environment: Environment):
+        car_config_id = await canopy.create_config(
+            environment.session,
+            'car',
+            test_car_name,
+            state.default_car.raw_data,
+            test_custom_properties)
+        weather_config_id = await canopy.create_config(
+            environment.session,
+            'weather',
+            test_weather_name,
+            state.default_weather.raw_data,
+            test_custom_properties)
+        default_exploration = await canopy.load_default_config(
+            environment.session,
+            'exploration',
+            default_exploration_name)
+
+        default_exploration.data.design.numberOfPoints = 2
+        default_exploration.properties = {
+            'type': 'a'
+        }
+        default_exploration.notes = exploration_notes
+
+        weather_config = await canopy.load_config(
+            environment.session, weather_config_id)
+
+        state.study_id_2 = await canopy.create_study(
+            environment.session,
+            'apexSim',
+            test_study_name_2,
+            [
+                car_config_id,
+                weather_config,
+                default_exploration,
+            ])
+        logger.info('Study ID 2 is {}'.format(state.study_id_2))
+
+        study = await self.wait_for_and_verify_study(state, environment, state.study_id_2, test_study_name_2)
+
+        properties = canopy.ensure_dict(study.document.properties)
+        assert test_study_property_value == properties['car.' + test_study_property_key]
+        assert test_study_property_value == properties['weather.' + test_study_property_key]
+        assert 'a' == properties['exploration.type']
+        assert study.simulation_count == 2
+        assert study.succeeded_simulation_count == 2
+        assert study.data.job_count == 3
+
+    async def test_0300_it_should_find_a_study_by_name(self, state: State, environment: Environment):
+        study = await canopy.find_study(
+            environment.session,
+            owner_username=environment.data.authentication.username,
+            name=test_study_name)
+
+        assert study.document.document_id == state.study_id
+
+    async def test_0400_it_should_find_a_study_by_custom_properties(self, state: State, environment: Environment):
+        study = await canopy.find_study(
+            environment.session,
+            owner_username=environment.data.authentication.username,
+            custom_properties=test_passed_though_custom_properties)
+
+        assert study.document.document_id == state.study_id_2
+        assert study.jobs is None
+
+    async def test_0500_it_should_find_a_study_by_multiple_criteria(self, state: State, environment: Environment):
+        study = await canopy.find_study(
+            environment.session,
+            owner_username=environment.data.authentication.username,
+            name=test_study_name_2,
+            custom_properties=test_passed_though_custom_properties)
+
+        assert study.document.document_id == state.study_id_2
+        assert study.jobs is None
+
+    async def test_0600_it_should_load_a_study_by_id(self, state: State, environment: Environment):
+        study = await canopy.load_study(
+            environment.session,
+            state.study_id)
+
+        assert study.document.document_id == state.study_id
+        assert study.inputs is None
+        assert study.sim_types is None
+        assert study.scalar_results is None
+
+        assert study.jobs is None
+
+    async def test_0610_it_should_load_a_study_by_id_with_data_when_no_study_scalar_results(self, state: State, environment: Environment):
+        study = await canopy.load_study(
+            environment.session,
+            state.study_id,
+            include_study_full_document=True,
+            include_study_scalar_results=True)
+
+        assert study.document.document_id == state.study_id
+        assert study.inputs is not None
+        assert study.sim_types is not None
+        assert study.scalar_results is not None
+        assert study.scalar_results.results is None
+        assert study.scalar_results.results_metadata is None
+        assert study.scalar_results.inputs is None
+        assert study.scalar_results.inputs_metadata is None
+
+        assert study.scalar_as('hRideF200:ApexSim', 'mm') is None
+        assert study.scalar_as('car.chassis.hRideFSetup+', 'mm') is None
+
+        assert study.jobs is None
+
+    async def test_0611_it_should_load_a_study_by_id_with_data_when_study_scalar_results_exist(self, state: State, environment: Environment):
+        study = await canopy.load_study(
+            environment.session,
+            state.study_id_2,
+            include_study_full_document=True,
+            include_study_scalar_results=True)
+
+        assert study.document.document_id == state.study_id_2
+        assert study.inputs is not None
+        assert study.sim_types is not None
+        assert study.scalar_results is not None
+        assert study.scalar_results.results is not None
+        assert study.scalar_results.results_metadata is not None
+        assert study.scalar_results.inputs is not None
+        assert study.scalar_results.inputs_metadata is not None
+
+        assert len(study.scalar_as('hRideF200:ApexSim', 'mm')) == 2
+        assert len(study.scalar_as('car.chassis.hRideFSetup+', 'mm')) == 2
+        assert study.scalar_results.units['hRideF200:ApexSim'] == 'm'
+        assert study.scalar_results.units['car.chassis.hRideFSetup+'] == 'm'
+
+        # Notes are only loaded with the full study document.
+        assert exploration_notes in study.document.notes
+
+        assert study.jobs is None
+
+    async def test_0620_it_should_load_a_study_by_id_with_job_metadata(self, state: State, environment: Environment):
+        study = await canopy.load_study(
+            environment.session,
+            state.study_id,
+            include_job_metadata=True)
+
+        assert study.document.document_id == state.study_id
+        assert 1 == len(study.jobs)
+
+        job = study.jobs[0]
+        assert job.result is not None
+        assert job.document is not None
+        assert job.inputs is None
+        assert 0 == len(job.scalar_data)
+        assert 0 == len(job.vector_data.columns)
+        assert 0 == len(job.vector_data)
+        assert job.vector_metadata is None
+
+    async def test_0700_it_should_load_a_study_by_id_with_data(self, state: State, environment: Environment):
+        study = await canopy.load_study(
+            environment.session,
+            state.study_id,
+            sim_type='apexSim',  # Intentionally wrong casing.
+            channel_names=[
+                'vCar',
+                'tLap',  # This channel won't exist.
+                'hRideF',
+            ],
+            include_job_inputs=True,
+            include_job_scalar_results=True)
+
+        assert study.document.document_id == state.study_id
+        assert 1 == len(study.jobs)
+
+        job = study.jobs[0]
+        assert job.result is not None
+        assert job.document is not None
+        assert job.inputs is not None
+        assert len(job.scalar_data) > 0
+        assert len(job.vector_data.columns) == 2
+        assert len(job.vector_data) > 10
+        assert len(job.vector_metadata) > 0
+
+        assert len(job.vector_as('vCar', 'kph')) > 0
+        assert job.vector_units['vCar'] == 'm/s'
+
+        assert job.scalar_as('hRideF200', 'mm') > 0
+        assert job.scalar_units['hRideF200'] == 'm'
+
+    async def test_0800_it_should_load_a_study_by_id_with_job_vector_metadata_only(self, state: State, environment: Environment):
+        study = await canopy.load_study(
+            environment.session,
+            state.study_id,
+            sim_type='ApexSim',
+            include_job_vector_metadata=True)
+
+        assert study.document.document_id == state.study_id
+        assert 1 == len(study.jobs)
+
+        job = study.jobs[0]
+        assert 0 == len(job.scalar_data)
+        assert 0 == len(job.vector_data.columns)
+        assert 0 == len(job.vector_data)
+        assert len(job.vector_metadata) > 0
+
+    async def test_9000_it_should_remove_configs(self, state: State, environment: Environment):
+        tasks: List[Future] = []
+        for config_id in state.configs_to_remove:
+            tasks.append(asyncio.ensure_future(canopy.delete_config(
                 environment.session,
-                'car',
-                default_car_name)
-            state.default_weather = await canopy.load_default_config(
+                config_id)))
+        await asyncio.gather(*tasks)
+
+    async def test_9100_it_should_remove_studies(self, state: State, environment: Environment):
+        tasks: List[Future] = []
+        for study_id in state.studies_to_remove:
+            tasks.append(asyncio.ensure_future(canopy.delete_study(
                 environment.session,
-                'weather',
-                default_weather_name)
-
-            state.study_id = await canopy.create_study(
-                environment.session,
-                'ApexSim',  # Intentionally wrong casing.
-                test_study_name,
-                [
-                    state.default_car,
-                    state.default_weather,
-                ],
-                test_custom_properties)
-            logger.info('Study ID is {}'.format(state.study_id))
-
-            study = await self.wait_for_and_verify_study(state, environment, state.study_id, test_study_name)
-
-            properties = canopy.ensure_dict(study.document.properties)
-            assert test_study_property_value == properties[test_study_property_key]
-            assert study.simulation_count == 1
-            assert study.succeeded_simulation_count == 1
-            assert study.data.job_count == 1
-
-    async def test_0200_it_should_create_a_study_from_references_and_loaded_configs(self, state: State):
-        async with integration_tests.Environment() as environment:
-            car_config_id = await canopy.create_config(
-                environment.session,
-                'car',
-                test_car_name,
-                state.default_car.raw_data,
-                test_custom_properties)
-            weather_config_id = await canopy.create_config(
-                environment.session,
-                'weather',
-                test_weather_name,
-                state.default_weather.raw_data,
-                test_custom_properties)
-            default_exploration = await canopy.load_default_config(
-                environment.session,
-                'exploration',
-                default_exploration_name)
-
-            default_exploration.data.design.numberOfPoints = 2
-            default_exploration.properties = {
-                'type': 'a'
-            }
-            default_exploration.notes = exploration_notes
-
-            weather_config = await canopy.load_config(
-                environment.session, weather_config_id)
-
-            state.study_id_2 = await canopy.create_study(
-                environment.session,
-                'apexSim',
-                test_study_name_2,
-                [
-                    car_config_id,
-                    weather_config,
-                    default_exploration,
-                ])
-            logger.info('Study ID 2 is {}'.format(state.study_id_2))
-
-            study = await self.wait_for_and_verify_study(state, environment, state.study_id_2, test_study_name_2)
-
-            properties = canopy.ensure_dict(study.document.properties)
-            assert test_study_property_value == properties['car.' + test_study_property_key]
-            assert test_study_property_value == properties['weather.' + test_study_property_key]
-            assert 'a' == properties['exploration.type']
-            assert study.simulation_count == 2
-            assert study.succeeded_simulation_count == 2
-            assert study.data.job_count == 3
-
-    async def test_0300_it_should_find_a_study_by_name(self, state: State):
-        async with integration_tests.Environment() as environment:
-            study = await canopy.find_study(
-                environment.session,
-                owner_username=environment.data.authentication.username,
-                name=test_study_name)
-
-            assert study.document.document_id == state.study_id
-
-    async def test_0400_it_should_find_a_study_by_custom_properties(self, state: State):
-        async with integration_tests.Environment() as environment:
-            study = await canopy.find_study(
-                environment.session,
-                owner_username=environment.data.authentication.username,
-                custom_properties=test_passed_though_custom_properties)
-
-            assert study.document.document_id == state.study_id_2
-            assert study.jobs is None
-
-    async def test_0500_it_should_find_a_study_by_multiple_criteria(self, state: State):
-        async with integration_tests.Environment() as environment:
-            study = await canopy.find_study(
-                environment.session,
-                owner_username=environment.data.authentication.username,
-                name=test_study_name_2,
-                custom_properties=test_passed_though_custom_properties)
-
-            assert study.document.document_id == state.study_id_2
-            assert study.jobs is None
-
-    async def test_0600_it_should_load_a_study_by_id(self, state: State):
-        async with integration_tests.Environment() as environment:
-            study = await canopy.load_study(
-                environment.session,
-                state.study_id)
-
-            assert study.document.document_id == state.study_id
-            assert study.inputs is None
-            assert study.sim_types is None
-            assert study.scalar_results is None
-
-            assert study.jobs is None
-
-    async def test_0610_it_should_load_a_study_by_id_with_data_when_no_study_scalar_results(self, state: State):
-        async with integration_tests.Environment() as environment:
-            study = await canopy.load_study(
-                environment.session,
-                state.study_id,
-                include_study_full_document=True,
-                include_study_scalar_results=True)
-
-            assert study.document.document_id == state.study_id
-            assert study.inputs is not None
-            assert study.sim_types is not None
-            assert study.scalar_results is not None
-            assert study.scalar_results.results is None
-            assert study.scalar_results.results_metadata is None
-            assert study.scalar_results.inputs is None
-            assert study.scalar_results.inputs_metadata is None
-
-            assert study.scalar_as('hRideF200:ApexSim', 'mm') is None
-            assert study.scalar_as('car.chassis.hRideFSetup+', 'mm') is None
-
-            assert study.jobs is None
-
-    async def test_0611_it_should_load_a_study_by_id_with_data_when_study_scalar_results_exist(self, state: State):
-        async with integration_tests.Environment() as environment:
-            study = await canopy.load_study(
-                environment.session,
-                state.study_id_2,
-                include_study_full_document=True,
-                include_study_scalar_results=True)
-
-            assert study.document.document_id == state.study_id_2
-            assert study.inputs is not None
-            assert study.sim_types is not None
-            assert study.scalar_results is not None
-            assert study.scalar_results.results is not None
-            assert study.scalar_results.results_metadata is not None
-            assert study.scalar_results.inputs is not None
-            assert study.scalar_results.inputs_metadata is not None
-
-            assert len(study.scalar_as('hRideF200:ApexSim', 'mm')) == 2
-            assert len(study.scalar_as('car.chassis.hRideFSetup+', 'mm')) == 2
-            assert study.scalar_results.units['hRideF200:ApexSim'] == 'm'
-            assert study.scalar_results.units['car.chassis.hRideFSetup+'] == 'm'
-
-            # Notes are only loaded with the full study document.
-            assert exploration_notes in study.document.notes
-
-            assert study.jobs is None
-
-    async def test_0620_it_should_load_a_study_by_id_with_job_metadata(self, state: State):
-        async with integration_tests.Environment() as environment:
-            study = await canopy.load_study(
-                environment.session,
-                state.study_id,
-                include_job_metadata=True)
-
-            assert study.document.document_id == state.study_id
-            assert 1 == len(study.jobs)
-
-            job = study.jobs[0]
-            assert job.result is not None
-            assert job.document is not None
-            assert job.inputs is None
-            assert 0 == len(job.scalar_data)
-            assert 0 == len(job.vector_data.columns)
-            assert 0 == len(job.vector_data)
-            assert job.vector_metadata is None
-
-    async def test_0700_it_should_load_a_study_by_id_with_data(self, state: State):
-        async with integration_tests.Environment() as environment:
-            study = await canopy.load_study(
-                environment.session,
-                state.study_id,
-                sim_type='apexSim',  # Intentionally wrong casing.
-                channel_names=[
-                    'vCar',
-                    'tLap',  # This channel won't exist.
-                    'hRideF',
-                ],
-                include_job_inputs=True,
-                include_job_scalar_results=True)
-
-            assert study.document.document_id == state.study_id
-            assert 1 == len(study.jobs)
-
-            job = study.jobs[0]
-            assert job.result is not None
-            assert job.document is not None
-            assert job.inputs is not None
-            assert len(job.scalar_data) > 0
-            assert len(job.vector_data.columns) == 2
-            assert len(job.vector_data) > 10
-            assert len(job.vector_metadata) > 0
-
-            assert len(job.vector_as('vCar', 'kph')) > 0
-            assert job.vector_units['vCar'] == 'm/s'
-
-            assert job.scalar_as('hRideF200', 'mm') > 0
-            assert job.scalar_units['hRideF200'] == 'm'
-
-    async def test_0800_it_should_load_a_study_by_id_with_job_vector_metadata_only(self, state: State):
-        async with integration_tests.Environment() as environment:
-            study = await canopy.load_study(
-                environment.session,
-                state.study_id,
-                sim_type='ApexSim',
-                include_job_vector_metadata=True)
-
-            assert study.document.document_id == state.study_id
-            assert 1 == len(study.jobs)
-
-            job = study.jobs[0]
-            assert 0 == len(job.scalar_data)
-            assert 0 == len(job.vector_data.columns)
-            assert 0 == len(job.vector_data)
-            assert len(job.vector_metadata) > 0
-
-    async def test_9000_it_should_remove_configs(self, state: State):
-        async with integration_tests.Environment() as environment:
-            tasks: List[Future] = []
-            for config_id in state.configs_to_remove:
-                tasks.append(asyncio.ensure_future(canopy.delete_config(
-                    environment.session,
-                    config_id)))
-            await asyncio.gather(*tasks)
-
-    async def test_9100_it_should_remove_studies(self, state: State):
-        async with integration_tests.Environment() as environment:
-            tasks: List[Future] = []
-            for study_id in state.studies_to_remove:
-                tasks.append(asyncio.ensure_future(canopy.delete_study(
-                    environment.session,
-                    study_id)))
-            await asyncio.gather(*tasks)
+                study_id)))
+        await asyncio.gather(*tasks)

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ aiohttp
 munch
 
 pytest-asyncio
+ipykernel


### PR DESCRIPTION
This PR is in 4 parts, because the repo was a little stale:

1. Update dev container files so I had a development environment to make the change.
    `.devcontainer/*`
    `.requirements.txt`  
3. Add the timeout option, and set a more sensible default.
    `canopy/session.py`
5. Update integration tests so they share an authentication token, so we don't trigger sign-in attempt thresholds, so I can test the change.
    `integration_tests/*`