### PR TITLE
Replace obsolete token API with OAuth2 identity endpoint

### DIFF
--- a/canopy/authentication.py
+++ b/canopy/authentication.py
@@ -1,13 +1,18 @@
 from typing import Optional
 
 import canopy
-import getpass
 import datetime
+import json
+import base64
+import urllib3
+import certifi
+
+
+_TOKEN_URL = 'https://identity.canopysimulations.com/connect/token'
 
 
 class Authentication(object):
     _client: canopy.openapi.ApiClient
-    _identity: canopy.openapi.models.GrantTypeHandlerResponse
 
     def __init__(
             self,
@@ -23,11 +28,14 @@ class Authentication(object):
         self._username = username
         self._tenant_name = tenant_name
         self._password = password
-        self._identity = None
+        self._access_token: Optional[str] = None
+        self._refresh_token: Optional[str] = None
+        self._tenant_id: Optional[str] = None
+        self._user_id: Optional[str] = None
         self._expires: datetime.datetime = datetime.datetime.min
 
     def authenticate(self):
-        if self._identity is None or self._expires is None:
+        if self._access_token is None:
             self.sign_in()
         elif datetime.datetime.now() >= self._expires:
             self.refresh_access_token()
@@ -46,50 +54,77 @@ class Authentication(object):
         self._tenant_name = authentication_data.tenant_name
         self._password = authentication_data.password
 
-        token_api = canopy.openapi.TokenApi(self._client)
+        token_response = self._request_token({
+            'grant_type': 'password',
+            'username': self._username,
+            'password': self._password,
+            'client_id': self._client_id,
+            'client_secret': self._client_secret,
+            'tenant': self._tenant_name,
+        })
 
-        token_result = token_api.token_post_token(
-            grant_type = 'password',
-            username = self._username,
-            tenant = self._tenant_name,
-            password = self._password,
-            client_id = self._client_id,
-            client_secret = self._client_secret)
-
-        self._identity = token_result
-        self.__update_from_identity()
+        claims = self._decode_jwt_payload(token_response['access_token'])
+        self._tenant_id = claims.get('tenant')
+        self._user_id = claims.get('sub')
+        self._refresh_token = token_response.get('refresh_token')
+        self._apply_token_response(token_response)
 
     def refresh_access_token(self):
-        if self._identity is None:
+        if self._refresh_token is None:
             raise RuntimeError('You must call authenticate before refreshing the access token.')
 
-        token_api = canopy.openapi.TokenApi(self._client)
+        token_response = self._request_token({
+            'grant_type': 'refresh_token',
+            'refresh_token': self._refresh_token,
+            'client_id': self._client_id,
+            'client_secret': self._client_secret,
+        })
 
-        token_result = token_api.token_post_token(
-            grant_type = 'refresh_token',
-            refresh_token = self._identity.refresh_token,
-            client_id = self._client_id,
-            client_secret = self._client_secret)
+        self._apply_token_response(token_response)
 
-        self._identity.access_token = token_result.access_token
-        self._identity.expires_in = token_result.expires_in
-        self.__update_from_identity()
+    def _request_token(self, fields: dict) -> dict:
+        proxy = self._client.configuration.proxy
+        ca_certs = self._client.configuration.ssl_ca_cert or certifi.where()
+        if proxy:
+            http = urllib3.ProxyManager(
+                proxy,
+                proxy_headers=self._client.configuration.proxy_headers,
+                ca_certs=ca_certs)
+        else:
+            http = urllib3.PoolManager(ca_certs=ca_certs)
 
-    def __update_from_identity(self):
-        self._client.configuration.access_token = self._identity.access_token
-        expires_delta = datetime.timedelta(seconds=self._identity.expires_in)
-        self._expires = datetime.datetime.now() + expires_delta
+        response = http.request(
+            'POST',
+            _TOKEN_URL,
+            fields=fields,
+            encode_multipart=False)
+
+        if response.status != 200:
+            raise RuntimeError(
+                f'Token endpoint returned HTTP {response.status}: {response.data.decode("utf-8")}')
+
+        return json.loads(response.data.decode('utf-8'))
+
+    def _apply_token_response(self, token_response: dict):
+        self._access_token = token_response['access_token']
+        self._client.configuration.access_token = self._access_token
+        self._expires = datetime.datetime.now() + datetime.timedelta(
+            seconds=token_response['expires_in'])
+
+    @staticmethod
+    def _decode_jwt_payload(token: str) -> dict:
+        payload = token.split('.')[1]
+        payload += '=' * (-len(payload) % 4)
+        return json.loads(base64.urlsafe_b64decode(payload))
 
     @property
     def tenant_id(self) -> str:
-        if self._identity is None:
+        if self._tenant_id is None:
             raise RuntimeError('You must call authenticate before requesting tenant ID.')
-
-        return self._identity.tenant_id
+        return self._tenant_id
 
     @property
     def user_id(self) -> str:
-        if self._identity is None:
+        if self._user_id is None:
             raise RuntimeError('You must call authenticate before requesting user ID.')
-
-        return self._identity.user_id
+        return self._user_id


### PR DESCRIPTION
## Summary

- Replaces the deprecated `TokenApi.token_post_token()` call (which targeted the obsolete `/token` endpoint on the main API host) with a direct `application/x-www-form-urlencoded` POST to `https://identity.canopysimulations.com/connect/token`.
- Supports both `password` and `refresh_token` grant types against the new endpoint.
- `tenant_id` and `user_id` are now extracted from the JWT access token payload (claims `tenant` and `sub`) rather than from fields in the token response body.
- Proxy settings from the session configuration are carried through to the token endpoint requests.
- No new dependencies — uses `urllib3`, `base64`, and `json`, all of which are already available.

## Test plan

- [x] Run unit tests: `pytest canopy`
- [x] Run integration tests with valid credentials to confirm sign-in and token refresh work end-to-end against the identity server
- [x] Verify `session.authentication.tenant_id` and `session.authentication.user_id` return the correct values after authenticating
- [ ] If applicable, verify a session configured with a `ProxyConfiguration` can still authenticate successfully